### PR TITLE
新增：支持将日志写入到文件

### DIFF
--- a/log.py
+++ b/log.py
@@ -11,7 +11,7 @@ import sys
 def outputLog():
     log = logging.getLogger('BILI_judgement')
     log.setLevel(level=logging.DEBUG)
-    formatter = logging.Formatter('[%(asctime)s] [%(name)s] [%(levelname)s]\t%(message)s')
+    formatter = logging.Formatter('[%(asctime)s] [%(levelname)s]\t%(message)s')
     # 输出日志到终端
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.formatter = formatter

--- a/log.py
+++ b/log.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# @Time    : 2022-05-03 20:29:29
+# @Author  : Qiuyelin
+# @File    : log.py
+# @Software: PyCharm
+
+import logging.config
+import sys
+
+def outputLog():
+    log = logging.getLogger('BILI_judgement')
+    log.setLevel(level=logging.DEBUG)
+    formatter = logging.Formatter('[%(asctime)s] [%(name)s] [%(levelname)s]\t%(message)s')
+    # 输出日志到终端
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.formatter = formatter
+    log.addHandler(console_handler)
+    #输出日志到文件
+    file_handler = logging.FileHandler('BILI_judgement.log')
+    file_handler.formatter = formatter
+    file_handler.level = logging.INFO
+    log.addHandler(file_handler)
+    return log

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,2 @@
+cd /d %~dp0 
+python judgement.py


### PR DESCRIPTION
使用任务计划程序（taskschd.msc）可设置定时运行脚本，但是日志不可见。通过将日志输出到文件，可帮助了解脚本运行情况。

如果直接使用任务计划程序调用脚本，那么日志文件将会出现在 “C:\Windows\System32” 文件夹下，如果你想让日志文件和脚本在同一个目录下，请在同目录下创建 .bat 文件：
```batch
cd /d %~dp0 
python judgement.py
```
通过 .bat 程序间接调用脚本，日志文件将始终会和脚本在同一个目录下。